### PR TITLE
Check request for null in ExecuteAsync

### DIFF
--- a/src/AspNetCoreCustom/Example/GraphQLMiddleware.cs
+++ b/src/AspNetCoreCustom/Example/GraphQLMiddleware.cs
@@ -56,9 +56,9 @@ namespace Example
             var result = await _executer.ExecuteAsync(_ =>
             {
                 _.Schema = schema;
-                _.Query = request.Query;
-                _.OperationName = request.OperationName;
-                _.Inputs = request.Variables.ToInputs();
+                _.Query = request?.Query;
+                _.OperationName = request?.OperationName;
+                _.Inputs = request?.Variables.ToInputs();
                 _.UserContext = _settings.BuildUserContext?.Invoke(context);
                 _.ValidationRules = DocumentValidator.CoreRules().Concat(new [] { new InputValidationRule() });
             });


### PR DESCRIPTION
If the request is empty it throws an exception which results in a hard error.
By handling null it responds with the correct error message: 

`{"errors":[{"message":"A query is required.","extensions":{"code":"EXECUTION_ERROR"}}]}`