### PR TITLE
Add ConfigureAwait(false) to ClientNet462 sample

### DIFF
--- a/src/ClientNet462/Program.cs
+++ b/src/ClientNet462/Program.cs
@@ -110,12 +110,12 @@ namespace Client
             };
             //add authorization headers if necessary here
             httpRequestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            using (var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken))
+            using (var response = await httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
             {
                 //if (response.IsSuccessStatusCode)
                 if (response?.Content.Headers.ContentType?.MediaType == "application/json")
                 {
-                    var responseString = await response.Content.ReadAsStringAsync(); //cancellationToken supported for .NET 5/6
+                    var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false); //cancellationToken supported for .NET 5/6
                     return DeserializeGraphQLCall<TResponse>(responseString);
                 }
                 else


### PR DESCRIPTION
Note: `ConfigureAwait(false)` was added to the "library" code, not to the sample code.  This is because users should not add `ConfigureAwait(false)` to their usage of the `CallGraphQLAsync` method, unless it's also within a "library" asynchronous method.