### PR TITLE
Add configuration to publishing using NativeAOT

### DIFF
--- a/src/AspNetCore/Example/Example.csproj
+++ b/src/AspNetCore/Example/Example.csproj
@@ -1,14 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <RestoreAdditionalProjectSources Condition="$(PublishNativeAot) == True">
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json;
+      $(RestoreAdditionalProjectSources)
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="4.2.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="4.2.0" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" Condition="$(PublishNativeAot) == True" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RdXmlFile Include="Microsoft.AspNetCore.rd.xml" />
+    <RdXmlFile Include="GraphQL.rd.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore/Example/GraphQL.rd.xml
+++ b/src/AspNetCore/Example/GraphQL.rd.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives>
+	<Application>
+		<Assembly Name="System.Text.Json">
+			<Type Name="System.Text.Json.Serialization.Converters.SmallObjectWithParameterizedConstructorConverter`5[[GraphQL.Instrumentation.ApolloTrace,GraphQL],[System.DateTime,System.Private.CoreLib],[System.Double,System.Private.CoreLib],[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+			<Type Name="System.Text.Json.Serialization.Converters.ListOfTConverter`2[[System.Collections.Generic.List`1[[GraphQL.Instrumentation.ApolloTrace+ResolverTrace,GraphQL]],System.Private.CoreLib],[GraphQL.Instrumentation.ApolloTrace+ResolverTrace,GraphQL]]" Dynamic="Required All" />
+		</Assembly>
+	</Application>
+</Directives>

--- a/src/AspNetCore/Example/Microsoft.AspNetCore.rd.xml
+++ b/src/AspNetCore/Example/Microsoft.AspNetCore.rd.xml
@@ -9,14 +9,6 @@
 		</Assembly>
 		<Assembly Name="Microsoft.AspNetCore.Mvc.Core" Dynamic="Required All">
 			<Type Name="Microsoft.Extensions.Internal.PropertyHelper">
-				<!--
-					Change WebApplication.Pages.ErrorModel to full type name of the ErrorModel
-					WebApplicationAssembly is name of your assembly where ErrorModel class is located.
-				-->
-				<!-- <Method Name="CallNullSafePropertyGetter" Dynamic="Required">
-					<GenericArgument Name="WebApplication.Pages.ErrorModel, WebApplicationAssembly" />
-					<GenericArgument Name="System.Boolean, System.Private.CoreLib" />
-				</Method> -->
 				<Method Name="CallPropertySetter" Dynamic="Required">
 					<GenericArgument Name="Microsoft.AspNetCore.Mvc.Razor.RazorPageBase, Microsoft.AspNetCore.Mvc.Razor" />
 					<GenericArgument Name="System.Boolean, System.Private.CoreLib" />

--- a/src/AspNetCore/Example/Microsoft.AspNetCore.rd.xml
+++ b/src/AspNetCore/Example/Microsoft.AspNetCore.rd.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Directives>
+	<Application>
+		<Assembly Name="System.Text.Json">
+			<Type Name="System.Text.Json.Serialization.Converters.DictionaryOfTKeyTValueConverter`3[[System.Collections.Generic.Dictionary`2[[System.String,System.Private.CoreLib],[System.Object,System.Private.CoreLib]],System.Private.CoreLib],[System.String,System.Private.CoreLib],[System.Object,System.Private.CoreLib]]" Dynamic="Required All" />
+		</Assembly>
+		<Assembly Name="Microsoft.AspNetCore.Mvc.Razor">
+			<Type Name="Microsoft.AspNetCore.Mvc.ApplicationParts.ConsolidatedAssemblyApplicationPartFactory" Dynamic="Required All" />
+		</Assembly>
+		<Assembly Name="Microsoft.AspNetCore.Mvc.Core" Dynamic="Required All">
+			<Type Name="Microsoft.Extensions.Internal.PropertyHelper">
+				<!--
+					Change WebApplication.Pages.ErrorModel to full type name of the ErrorModel
+					WebApplicationAssembly is name of your assembly where ErrorModel class is located.
+				-->
+				<!-- <Method Name="CallNullSafePropertyGetter" Dynamic="Required">
+					<GenericArgument Name="WebApplication.Pages.ErrorModel, WebApplicationAssembly" />
+					<GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+				</Method> -->
+				<Method Name="CallPropertySetter" Dynamic="Required">
+					<GenericArgument Name="Microsoft.AspNetCore.Mvc.Razor.RazorPageBase, Microsoft.AspNetCore.Mvc.Razor" />
+					<GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+				</Method>
+			</Type>
+		</Assembly>
+	</Application>
+</Directives>

--- a/src/AspNetCore/README.md
+++ b/src/AspNetCore/README.md
@@ -7,7 +7,7 @@
 
 If you like to try GraphQL compile using [NativeAOT](https://github.com/dotnet/runtimelab/issues/248) which should [happens](https://github.com/dotnet/runtime/issues/61231) in .NET 7
 
-Native AOT form-factor of .NET allow startup time in tens of milliseconds, and high performance and predictability (no JIT). If you know to AOT, you can start reading about rationale for it [here](https://github.com/dotnet/designs/blob/main/accepted/2020/form-factors.md#native-aot-form-factors).
+Native AOT (ahead-of-time) compilation in .NET allows startup time in tens of milliseconds, with high performance and predictability, eliminating JIT (just-in-time) compilation. If you are new to AOT compilation, you can start reading about rationale for it [here](https://github.com/dotnet/designs/blob/main/accepted/2020/form-factors.md#native-aot-form-factors).
 
 **Note**. In your applications, due to reflection, you may need to edit RD.xml files provided in this sample. More about it in [the docs](https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/rd-xml-format.md)
 

--- a/src/AspNetCore/README.md
+++ b/src/AspNetCore/README.md
@@ -5,7 +5,7 @@
 > browse to http://localhost:3000/ui/playground
 ```
 
-If you like to try GraphQL compile using [NativeAOT](https://github.com/dotnet/runtimelab/issues/248) which should [happens](https://github.com/dotnet/runtime/issues/61231) in .NET 7
+If you like to try GraphQL compiled using [NativeAOT](https://github.com/dotnet/runtimelab/issues/248) which should [happen](https://github.com/dotnet/runtime/issues/61231) in .NET 7
 
 Native AOT (ahead-of-time) compilation in .NET allows startup time in tens of milliseconds, with high performance and predictability, eliminating JIT (just-in-time) compilation. If you are new to AOT compilation, you can start reading about rationale for it [here](https://github.com/dotnet/designs/blob/main/accepted/2020/form-factors.md#native-aot-form-factors).
 

--- a/src/AspNetCore/README.md
+++ b/src/AspNetCore/README.md
@@ -5,7 +5,11 @@
 > browse to http://localhost:3000/ui/playground
 ```
 
-If you like to try GraphQL compile using NativeAOT
+If you like to try GraphQL compile using [NativeAOT](https://github.com/dotnet/runtimelab/issues/248) which should [happens](https://github.com/dotnet/runtime/issues/61231) in .NET 7
+
+Native AOT form-factor of .NET allow startup time in tens of milliseconds, and high performance and predictability (no JIT). If you know to AOT, you can start reading about rationale for it [here](https://github.com/dotnet/designs/blob/main/accepted/2020/form-factors.md#native-aot-form-factors).
+
+**Note**. In your applications, due to reflection, you may need to edit RD.xml files provided in this sample. More about it in [the docs](https://github.com/dotnet/runtimelab/blob/feature/NativeAOT/docs/using-nativeaot/rd-xml-format.md)
 
 ```
 > ./nativeaot.sh

--- a/src/AspNetCore/README.md
+++ b/src/AspNetCore/README.md
@@ -4,3 +4,10 @@
 > ./run.sh
 > browse to http://localhost:3000/ui/playground
 ```
+
+If you like to try GraphQL compile using NativeAOT
+
+```
+> ./nativeaot.sh
+> browse to http://localhost:3000/ui/playground
+```

--- a/src/AspNetCore/nativeaot.cmd
+++ b/src/AspNetCore/nativeaot.cmd
@@ -1,0 +1,4 @@
+cd Example
+dotnet restore
+dotnet publish -c Release -r win-x64 -p:PublishNativeAot=True
+bin/Release/net6.0/win-x64/publish/Example

--- a/src/AspNetCore/nativeaot.sh
+++ b/src/AspNetCore/nativeaot.sh
@@ -3,6 +3,6 @@
 cd Example
 dotnet restore
 dotnet publish -c Release -r linux-x64 -p:PublishNativeAot=True
-# Uncomment to get rid of debugging symbols in executable
-#strip bin/Release/net6.0/linux-x64/publish/Example
+# Comment line below if you want preserve debug symbols in the executable
+strip bin/Release/net6.0/linux-x64/publish/Example
 bin/Release/net6.0/linux-x64/publish/Example

--- a/src/AspNetCore/nativeaot.sh
+++ b/src/AspNetCore/nativeaot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd Example
+dotnet restore
+dotnet publish -c Release -r linux-x64 -p:PublishNativeAot=True
+# Uncomment to get rid of debugging symbols in executable
+#strip bin/Release/net6.0/linux-x64/publish/Example
+bin/Release/net6.0/linux-x64/publish/Example

--- a/src/AspNetCore/run.cmd
+++ b/src/AspNetCore/run.cmd
@@ -1,0 +1,3 @@
+cd Example
+dotnet restore
+dotnet run


### PR DESCRIPTION
To run use nativeaot.sh
By default with debug symbols app size is 200Mb
After strip debug symbols app size 76Mb.
Startup almost instaneneous even on old hardware.