### PR TITLE
Update examples with new builder methods to replace obsolete members

### DIFF
--- a/src/AspNetCore/Example/Example.csproj
+++ b/src/AspNetCore/Example/Example.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="4.7.1" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.2.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.2.0" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" Condition="$(PublishNativeAot) == True" />

--- a/src/AspNetCoreCustom/Example/Example.csproj
+++ b/src/AspNetCoreCustom/Example/Example.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.2.0" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="4.7.1" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCoreCustom/Example/GraphQLRequest.cs
+++ b/src/AspNetCoreCustom/Example/GraphQLRequest.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Example
 {
@@ -8,6 +8,6 @@ namespace Example
 
         public string Query { get; set; }
 
-        public JObject Variables { get; set; }
+        public JsonElement Variables { get; set; }
     }
 }

--- a/src/AspNetCoreCustom/Example/public/index.html
+++ b/src/AspNetCoreCustom/Example/public/index.html
@@ -1,12 +1,78 @@
+<!--
+ *  Copyright (c) 2021 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found at
+ *  https://github.com/graphql/graphiql/blob/d3e00052cdfbca4912713e9287aa7d636d947c2f/LICENSE
+-->
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>GraphiQL</title>
-    <link rel="stylesheet" href="/bundle.css" />
+  <style>
+    body {
+      height: 100%;
+      margin: 0;
+      width: 100%;
+      overflow: hidden;
+    }
+
+    #graphiql {
+      height: 100vh;
+    }
+  </style>
+
+  <!--
+    This GraphiQL example depends on Promise and fetch, which are available in
+    modern browsers, but can be "polyfilled" for older browsers.
+    GraphiQL itself depends on React DOM.
+    If you do not want to rely on a CDN, you can host these files locally or
+    include them directly in your favored resource bunder.
+  -->
+  <script crossorigin
+          src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script crossorigin
+          src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+
+  <!--
+    These two files can be found in the npm module, however you may wish to
+    copy them directly into your environment, or perhaps include them in your
+    favored resource bundler.
+   -->
+  <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
 </head>
+
 <body>
-    <div id="app"></div>
-    <script src="/bundle.js" type="text/javascript"></script>
+  <div id="graphiql">Loading...</div>
+  <script src="https://unpkg.com/graphiql/graphiql.min.js"
+          type="application/javascript"></script>
+  <script src="/renderExample.js" type="application/javascript"></script>
+  <script>
+    function graphQLFetcher(graphQLParams) {
+      return fetch(
+        '/api/graphql',
+        {
+          method: 'post',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(graphQLParams),
+          credentials: 'omit',
+        },
+      ).then(function (response) {
+        return response.json().catch(function () {
+          return response.text();
+        });
+      });
+    }
+
+    ReactDOM.render(
+      React.createElement(GraphiQL, {
+        fetcher: graphQLFetcher,
+        defaultVariableEditorOpen: true,
+      }),
+      document.getElementById('graphiql'),
+    );
+  </script>
 </body>
+</html>

--- a/src/AspNetCoreMulti/Example/Example.csproj
+++ b/src/AspNetCoreMulti/Example/Example.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="4.7.1" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.SystemTextJson" Version="5.2.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.2.0" />
   </ItemGroup>

--- a/src/AspNetCoreMulti/Example/Startup.cs
+++ b/src/AspNetCoreMulti/Example/Startup.cs
@@ -1,3 +1,4 @@
+using GraphQL;
 using GraphQL.Server;
 using GraphQL.Server.Ui.Playground;
 using Microsoft.AspNetCore.Builder;
@@ -12,21 +13,17 @@ namespace Example
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<DogSchema>();
-            services.AddSingleton<DogQuery>();
-            services.AddSingleton<CatSchema>();
-            services.AddSingleton<CatQuery>();
+            GraphQL.MicrosoftDI.GraphQLBuilderExtensions.AddGraphQL(services)
+                .AddServer(true, opt => opt.EnableMetrics = true)
+                .AddUserContextBuilder(httpContext => new GraphQLUserContext { User = httpContext.User })
+                .AddSchema<CatSchema>()
+                .AddSchema<DogSchema>()
+                .AddSystemTextJson()
+                .AddErrorInfoProvider(opt => opt.ExposeExceptionStackTrace = true)
+                .AddGraphTypes();
 
             services.AddLogging(builder => builder.AddConsole());
             services.AddHttpContextAccessor();
-
-#pragma warning disable CS0612 // Type or member is obsolete
-            services
-                .AddGraphQL(options => options.EnableMetrics = true)
-                .AddErrorInfoProvider(opt => opt.ExposeExceptionStackTrace = true)
-                .AddSystemTextJson()
-                .AddUserContextBuilder(httpContext => new GraphQLUserContext { User = httpContext.User });
-#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)


### PR DESCRIPTION
Fixes issues:
- #88 
- `AspNetCoreCustom` does not have working sample GraphiQL interface